### PR TITLE
updating checkout to use fetch-depth:0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+          fetch-depth: 0
     - uses: actions/cache@v4
       with:
        path: |


### PR DESCRIPTION
The git diff command was failing since we had not fetched origin/main